### PR TITLE
Record the time the job spent in the queue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,4 +44,4 @@ DEPENDENCIES
   sidekiq-datadog!
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/spec/sidekiq/middleware/server/datadog_spec.rb
+++ b/spec/sidekiq/middleware/server/datadog_spec.rb
@@ -9,18 +9,20 @@ describe Sidekiq::Middleware::Server::Datadog do
   subject { described_class.new hostname: "test.host", statsd: statsd, tags: ["custom:tag", lambda{|w, *| "worker:#{w.class.name[1..2]}" }] }
 
   it 'should send an increment and timing event for each job run' do
-    subject.call(worker, {}, 'default') { "ok" }
+    subject.call(worker, { "created_at" => 1461881794.9312189 }, 'default') { "ok" }
     expect(statsd.buffer).to eq([
       "sidekiq.job:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,queue:default,status:ok",
       "sidekiq.job.time:333|ms|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,queue:default,status:ok",
+      "sidekiq.job.queued_time:333|ms|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,queue:default,status:ok",
     ])
   end
 
   it 'should support wrappers' do
-    subject.call(worker, {'wrapped' => 'wrap'}, nil) { "ok" }
+    subject.call(worker, { 'created_at' => 1461881794.9312189, 'wrapped' => 'wrap'}, nil) { "ok" }
     expect(statsd.buffer).to eq([
       "sidekiq.job:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:wrap,status:ok",
       "sidekiq.job.time:333|ms|#custom:tag,worker:oc,host:test.host,env:test,name:wrap,status:ok",
+      "sidekiq.job.queued_time:333|ms|#custom:tag,worker:oc,host:test.host,env:test,name:wrap,status:ok",
     ])
   end
 


### PR DESCRIPTION
It would be a useful metric for me and my company to track how long jobs
are in the queue, so we can alert on an increase in that timing, letting
use know something is wrong, or we need to add more workers/threads,
etc. This tracks queued_time by subtracting the `start` time from the
job's `created_at`, which should be when it was enqueued.
