### PR TITLE
Use enqueued_at rather than created_at for queued_ms metric

### DIFF
--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -57,9 +57,7 @@ module Sidekiq
 
           def record(worker, job, queue, start, error = nil)
             ms   = ((Time.now - start) * 1000).round
-            if job["created_at"]
-              queued_ms = start - Time.at(job["created_at"])
-            end
+            queued_ms = start - Time.at(job["enqueued _at"])
             name = underscore(job['wrapped'] || worker.class.to_s)
             tags = @tags.map do |tag|
               case tag when String then tag when Proc then tag.call(worker, job, queue, error) end
@@ -77,9 +75,7 @@ module Sidekiq
 
             @statsd.increment @metric_name, :tags => tags
             @statsd.timing "#{@metric_name}.time", ms, :tags => tags
-            if queued_ms
-              @statsd.timing "#{@metric_name}.queued_time", queued_ms, :tags => tags
-            end
+            @statsd.timing "#{@metric_name}.queued_time", queued_ms, :tags => tags
           end
 
           def underscore(word)

--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -57,7 +57,9 @@ module Sidekiq
 
           def record(worker, job, queue, start, error = nil)
             ms   = ((Time.now - start) * 1000).round
-            queued_ms = start - Time.at(job["enqueued _at"])
+            if job.key?["enqueued_at"]
+              queued_ms = start - Time.at(job["enqueued _at"])
+            end
             name = underscore(job['wrapped'] || worker.class.to_s)
             tags = @tags.map do |tag|
               case tag when String then tag when Proc then tag.call(worker, job, queue, error) end
@@ -75,7 +77,9 @@ module Sidekiq
 
             @statsd.increment @metric_name, :tags => tags
             @statsd.timing "#{@metric_name}.time", ms, :tags => tags
-            @statsd.timing "#{@metric_name}.queued_time", queued_ms, :tags => tags
+            if queued_ms
+              @statsd.timing "#{@metric_name}.queued_time", queued_ms, :tags => tags
+            end
           end
 
           def underscore(word)

--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -57,8 +57,8 @@ module Sidekiq
 
           def record(worker, job, queue, start, error = nil)
             ms   = ((Time.now - start) * 1000).round
-            if job.key?["enqueued_at"]
-              queued_ms = start - Time.at(job["enqueued _at"])
+            if job["enqueued_at"]
+              queued_ms = start - Time.at(job["enqueued_at"])
             end
             name = underscore(job['wrapped'] || worker.class.to_s)
             tags = @tags.map do |tag|

--- a/spec/sidekiq/middleware/server/datadog_spec.rb
+++ b/spec/sidekiq/middleware/server/datadog_spec.rb
@@ -9,7 +9,7 @@ describe Sidekiq::Middleware::Server::Datadog do
   subject { described_class.new hostname: "test.host", statsd: statsd, tags: ["custom:tag", lambda{|w, *| "worker:#{w.class.name[1..2]}" }] }
 
   it 'should send an increment and timing event for each job run' do
-    subject.call(worker, { "created_at" => 1461881794.9312189 }, 'default') { "ok" }
+    subject.call(worker, { 'enqueued_at' => 1461881794.9312189 }, 'default') { "ok" }
     expect(statsd.buffer).to eq([
       "sidekiq.job:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,queue:default,status:ok",
       "sidekiq.job.time:333|ms|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,queue:default,status:ok",
@@ -18,7 +18,7 @@ describe Sidekiq::Middleware::Server::Datadog do
   end
 
   it 'should support wrappers' do
-    subject.call(worker, { 'created_at' => 1461881794.9312189, 'wrapped' => 'wrap'}, nil) { "ok" }
+    subject.call(worker, { 'enqueued_at' => 1461881794.9312189, 'wrapped' => 'wrap'}, nil) { "ok" }
     expect(statsd.buffer).to eq([
       "sidekiq.job:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:wrap,status:ok",
       "sidekiq.job.time:333|ms|#custom:tag,worker:oc,host:test.host,env:test,name:wrap,status:ok",


### PR DESCRIPTION
When a job has an error and is retried, potentially with exponential backoff, computing from created_at will include those retries and backoff periods as part of the queued_ms. Which is not an actual indication of how long the job was waiting in a queue ready to execute.

Using enqueued_at calculates the time from when a job was actually pushed to the target queue.
