### PR TITLE
Updated queued_ms stat to actually be ms

### DIFF
--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -58,7 +58,7 @@ module Sidekiq
           def record(worker, job, queue, start, error = nil)
             ms   = ((Time.now - start) * 1000).round
             if job["enqueued_at"]
-              queued_ms = start - Time.at(job["enqueued_at"])
+              queued_ms = ((start - Time.at(job["enqueued_at"])) * 1000).round
             end
             name = underscore(job['wrapped'] || worker.class.to_s)
             tags = @tags.map do |tag|


### PR DESCRIPTION
The previous, and original, `queued_ms` stats were actually reporting seconds. Updated stat computation to report ms as advertised. 
