### PR TITLE
Flatten dynamic tags

### DIFF
--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -61,7 +61,7 @@ module Sidekiq
               queued_ms = ((start - Time.at(job["enqueued_at"])) * 1000).round
             end
             name = underscore(job['wrapped'] || worker.class.to_s)
-            tags = @tags.map do |tag|
+            tags = @tags.flat_map do |tag|
               case tag when String then tag when Proc then tag.call(worker, job, queue, error) end
             end
 

--- a/spec/sidekiq/middleware/server/datadog_spec.rb
+++ b/spec/sidekiq/middleware/server/datadog_spec.rb
@@ -4,9 +4,12 @@ describe Sidekiq::Middleware::Server::Datadog do
 
   let(:statsd) { Mock::Statsd.new(nil, nil, {}, 10000) }
   let(:worker) { Mock::Worker.new }
+  let(:tags) {
+    ["custom:tag", lambda{|w, *| "worker:#{w.class.name[1..2]}" }]
+  }
 
   before  { statsd.written.clear }
-  subject { described_class.new hostname: "test.host", statsd: statsd, tags: ["custom:tag", lambda{|w, *| "worker:#{w.class.name[1..2]}" }] }
+  subject { described_class.new hostname: "test.host", statsd: statsd, tags: tags }
 
   it 'should send an increment and timing event for each job run' do
     subject.call(worker, { 'enqueued_at' => 1461881794.9312189 }, 'default') { "ok" }
@@ -35,6 +38,22 @@ describe Sidekiq::Middleware::Server::Datadog do
       "sidekiq.job:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,status:error,error:runtime",
       "sidekiq.job.time:333|ms|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,status:error,error:runtime",
     ])
+  end
+
+  context 'with a dynamic tag list' do
+    let(:tags) {
+      ["custom:tag", lambda {|w, j, *| j['args'].map { |n| "arg:#{n}"} }]
+    }
+
+    it 'should generate the correct tags' do
+      subject.call(worker, { 'enqueued_at' => 1461881794.9312189, 'args' => [1, 2] }, 'default') { "ok" }
+
+      expect(statsd.written).to eq([
+        "sidekiq.job:1|c|#custom:tag,arg:1,arg:2,host:test.host,env:test,name:mock/worker,queue:default,status:ok",
+        "sidekiq.job.time:333|ms|#custom:tag,arg:1,arg:2,host:test.host,env:test,name:mock/worker,queue:default,status:ok",
+        "sidekiq.job.queued_time:333|ms|#custom:tag,arg:1,arg:2,host:test.host,env:test,name:mock/worker,queue:default,status:ok"
+      ])
+    end
   end
 
 end


### PR DESCRIPTION
Right now we don't have a great way to write generic middleware that could generate 0-to-many tags. We can support this pretty easily by allowing tagging procs to return a list of tags, and flattening out the list before tagging.

I'm new to this gem, so if I'm missing something or if there's a better way to accomplish this, please let me know. 