### PR TITLE
Allow ignoring arbitrary tags

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,27 +10,28 @@ GEM
   specs:
     connection_pool (2.2.2)
     diff-lcs (1.3)
-    dogstatsd-ruby (4.0.0)
-    rack (2.0.6)
-    rack-protection (2.0.4)
+    dogstatsd-ruby (4.2.0)
+    rack (2.0.7)
+    rack-protection (2.0.5)
       rack
-    rake (12.3.1)
-    redis (4.0.3)
+    rake (12.3.2)
+    redis (4.1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    sidekiq (5.2.3)
+    sidekiq (5.2.7)
       connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
 
@@ -44,4 +45,4 @@ DEPENDENCIES
   sidekiq-datadog!
 
 BUNDLED WITH
-   1.16.4
+   2.0.1

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ executed at runtime when the job is processed
 #### supported options
  - *hostname* - the hostname used for instrumentation, defaults to system hostname. Can also be set with the `INSTRUMENTATION_HOSTNAME` env var.
  - *metric_name* - the metric name (prefix) to use, defaults to "sidekiq.job".
- - *tags* - array of custom tags. These can be plain strings or lambda blocks
+ - *tags* - array of custom tags. These can be plain strings or lambda blocks.
+ - *skip_tags* - array of tag names that shouldn't be emitted.
  - *statsd_host* - the statsD host, defaults to "localhost". Can also be set with the `STATSD_HOST` env var
  - *statsd_port* - the statsD port, defaults to 8125. Can also be set with the `STATSD_PORT` env var
  - *statsd* - custom statsd instance

--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -20,6 +20,7 @@ module Sidekiq
         # * <tt>:hostname</tt>    - the hostname used for instrumentation, defaults to system hostname, respects +INSTRUMENTATION_HOSTNAME+ env variable
         # * <tt>:metric_name</tt> - the metric name (prefix) to use, defaults to "sidekiq.job"
         # * <tt>:tags</tt>        - array of custom tags, these can be plain strings or lambda blocks accepting a rack env instance
+        # * <tt>:skip_tags</tt>   - array of tag names that shouldn't be emitted
         # * <tt>:statsd_host</tt> - the statsD host, defaults to "localhost", respects +STATSD_HOST+ env variable
         # * <tt>:statsd_port</tt> - the statsD port, defaults to 8125, respects +STATSD_PORT+ env variable
         # * <tt>:statsd</tt>      - custom statsd instance
@@ -31,13 +32,14 @@ module Sidekiq
           @metric_name  = opts[:metric_name] || "sidekiq.job"
           @statsd       = opts[:statsd] || ::Datadog::Statsd.new(statsd_host, statsd_port)
           @tags         = opts[:tags] || []
+          @skipped_tags = (opts[:skip_tags] || []).map(&:to_s)
 
-          if @tags.none? {|t| t =~ /^host\:/ }
+          if include_tag?(:host) && @tags.none? { |t| t =~ /^host\:/ }
             @tags.push("host:#{hostname}")
           end
 
           env = Sidekiq.options[:environment] || ENV['RACK_ENV']
-          if env && @tags.none? {|t| t =~ /^env\:/ }
+          if env && include_tag?(:env) && @tags.none? { |t| t =~ /^env\:/ }
             @tags.push("env:#{ENV['RACK_ENV']}")
           end
         end
@@ -47,7 +49,7 @@ module Sidekiq
           begin
             yield
             record(worker, job, queue, start)
-          rescue => e
+          rescue StandardError => e
             record(worker, job, queue, start, e)
             raise
           end
@@ -55,41 +57,49 @@ module Sidekiq
 
         private
 
-          def record(worker, job, queue, start, error = nil)
-            ms   = ((Time.now - start) * 1000).round
-            if job["enqueued_at"]
-              queued_ms = ((start - Time.at(job["enqueued_at"])) * 1000).round
-            end
-            name = underscore(job['wrapped'] || worker.class.to_s)
-            tags = @tags.flat_map do |tag|
-              case tag when String then tag when Proc then tag.call(worker, job, queue, error) end
-            end
-
-            tags.push "name:#{name}"
-            tags.push "queue:#{queue}" if queue
-            if error
-              kind = underscore(error.class.name.sub(/Error$/, ''))
-              tags.push "status:error", "error:#{kind}"
-            else
-              tags.push "status:ok"
-            end
-            tags.compact!
-
-            @statsd.increment @metric_name, :tags => tags
-            @statsd.timing "#{@metric_name}.time", ms, :tags => tags
-            if queued_ms
-              @statsd.timing "#{@metric_name}.queued_time", queued_ms, :tags => tags
+        def record(worker, job, queue, start, error = nil)
+          ms = ((Time.now - start) * 1000).round
+          name = underscore(job['wrapped'] || worker.class.to_s)
+          tags = @tags.flat_map do |tag|
+            case tag
+            when String then tag
+            when Proc then tag.call(worker, job, queue, error)
             end
           end
 
-          def underscore(word)
-            word = word.to_s.gsub(/::/, '/')
-            word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
-            word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-            word.tr!("-", "_")
-            word.downcase
+          tags.push "name:#{name}" if include_tag?(:name)
+          tags.push "queue:#{queue}" if queue && include_tag?(:queue)
+
+          if error
+            kind = underscore(error.class.name.sub(/Error$/, ''))
+            tags.push 'status:error' if include_tag?(:status)
+            tags.push "error:#{kind}" if include_tag?(:error)
+          else
+            tags.push 'status:ok' if include_tag?(:status)
           end
 
+          tags.compact!
+
+          @statsd.increment @metric_name, tags: tags
+          @statsd.timing "#{@metric_name}.time", ms, tags: tags
+
+          if job['enqueued_at']
+            queued_ms = ((start - Time.at(job['enqueued_at'])) * 1000).round
+            @statsd.timing "#{@metric_name}.queued_time", queued_ms, tags: tags
+          end
+        end
+
+        def include_tag?(tag)
+          !@skipped_tags.include?(tag.to_s)
+        end
+
+        def underscore(word)
+          word = word.to_s.gsub(/::/, '/')
+          word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
+          word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+          word.tr!("-", "_")
+          word.downcase
+        end
       end
     end
   end


### PR DESCRIPTION
This change will allow skipping unwanted tags. For example, in some
clusters Datadog agent may be set up to provide some tags, such as
`env` or `host` automatically.