### PR TITLE
Use Process#clock_gettime instead of Time.now

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    timecop (0.9.1)
     unicode-display_width (1.5.0)
 
 PLATFORMS
@@ -59,6 +60,7 @@ DEPENDENCIES
   rspec
   rubocop
   sidekiq-datadog!
+  timecop
 
 BUNDLED WITH
    2.0.1

--- a/sidekiq-datadog.gemspec
+++ b/sidekiq-datadog.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')
   s.add_development_dependency('rubocop')
+  s.add_development_dependency('timecop')
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,11 @@
 ENV['RACK_ENV'] ||= 'test'
 require 'sidekiq-datadog'
+require 'timecop'
 
 module Mock
-  class Worker
-  end
+  class Worker; end
 
   class Statsd < ::Datadog::Statsd
-    def timing(stat, _millis, opts={})
-      super(stat, 333, opts)
-    end
-
     def send_stat(message)
       messages.push message
     end


### PR DESCRIPTION
I think this article about [measuring elapsed time in Ruby](https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/) makes sense. It's done this way using `Process#clock_gettime` in the [`Benchmark` module](https://ruby-doc.org/stdlib-2.3.0/libdoc/benchmark/rdoc/Benchmark.html#method-c-measure) too.

So I thought we should do the same here.