### PR TITLE
Add Rubocop to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ rvm:
   - 2.5
   - 2.4
   - 2.3
+script:
+  - bundle exec rubocop
+  - bundle exec rspec


### PR DESCRIPTION
Since Rubocop has been added to the project, I thought we could make sure Travis is running it.