### PR TITLE
Fix NameError raised when used in conjunction with sidekiq/api

### DIFF
--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -42,7 +42,7 @@ module Sidekiq
 
         def call(worker, job, queue, *)
           start = Time.now
-          clock = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+          clock = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :millisecond)
 
           begin
             yield
@@ -56,7 +56,7 @@ module Sidekiq
         private
 
         def record(worker, job, queue, start, clock, error=nil) # rubocop:disable Metrics/ParameterLists
-          msec = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - clock
+          msec = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :millisecond) - clock
           tags = build_tags(worker, job, queue, error)
 
           @statsd.increment @metric_name, tags: tags

--- a/spec/sidekiq/middleware/server/datadog_spec.rb
+++ b/spec/sidekiq/middleware/server/datadog_spec.rb
@@ -93,4 +93,16 @@ describe Sidekiq::Middleware::Server::Datadog do
       ])
     end
   end
+
+  context 'when sidekiq/api is required' do
+    before do
+      require 'sidekiq/api'
+    end
+
+    it 'should not raise any errors' do
+      expect {
+        subject.call(worker, { 'enqueued_at' => enqueued_at }, 'default') { 'ok' }
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/sidekiq/middleware/server/datadog_spec.rb
+++ b/spec/sidekiq/middleware/server/datadog_spec.rb
@@ -100,9 +100,9 @@ describe Sidekiq::Middleware::Server::Datadog do
     end
 
     it 'should not raise any errors' do
-      expect {
+      expect do
         subject.call(worker, { 'enqueued_at' => enqueued_at }, 'default') { 'ok' }
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Sidekiq itself defines a Process class that is part of the API, commonly used by the Sidekiq Web UI. This PR explicitly uses Ruby's Process module in order to avoid errors like this:

```
NameError: uninitialized constant Sidekiq::Process::CLOCK_MONOTONIC
```