### PR TITLE
Track jobs enqueued through a Client middleware

### DIFF
--- a/lib/sidekiq-datadog.rb
+++ b/lib/sidekiq-datadog.rb
@@ -1,1 +1,2 @@
+require 'sidekiq/middleware/client/datadog'
 require 'sidekiq/middleware/server/datadog'

--- a/lib/sidekiq/datadog/tag_builder.rb
+++ b/lib/sidekiq/datadog/tag_builder.rb
@@ -1,0 +1,67 @@
+module Sidekiq
+  module Datadog
+    class TagBuilder
+      def initialize(custom_tags = [], skip_tags = [], custom_hostname = nil)
+        @tags = Array(custom_tags)
+        @skip_tags = Array(skip_tags).map(&:to_s)
+
+        env  = Sidekiq.options[:environment] || ENV['RACK_ENV']
+        host = custom_hostname || ENV['INSTRUMENTATION_HOSTNAME'] || Socket.gethostname
+        setup_defaults(host: host, env: env)
+      end
+
+      def build_tags(worker, job, queue = nil, error = nil)
+        tags = @tags.flat_map do |tag|
+          case tag
+          when String then tag
+          when Proc then tag.call(worker, job, queue, error)
+          end
+        end
+        tags.compact!
+
+        tags.push "name:#{job_name(worker, job)}" if include_tag?('name')
+        tags.push "queue:#{queue}" if queue && include_tag?('queue')
+
+        if error.nil?
+          tags.push 'status:ok' if include_tag?('status')
+        else
+          kind = underscore(error.class.name.sub(/Error$/, ''))
+          tags.push 'status:error' if include_tag?('status')
+          tags.push "error:#{kind}" if include_tag?('error')
+        end
+
+        tags
+      end
+
+      private
+
+      def job_name(worker, job)
+        underscore(job['wrapped'] || worker.class.to_s)
+      end
+
+      def setup_defaults(hash)
+        hash.each do |key, val|
+          key = key.to_s
+          next unless val && include_tag?(key)
+
+          prefix = "#{key}:"
+          next if @tags.any? {|t| t.is_a?(String) && t.start_with?(prefix) }
+
+          @tags.push [key, val].join(':')
+        end
+      end
+
+      def include_tag?(tag)
+        !@skip_tags.include?(tag)
+      end
+
+      def underscore(word)
+        word = word.to_s.gsub(/::/, '/')
+        word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+        word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+        word.tr!('-', '_')
+        word.downcase
+      end
+    end
+  end
+end

--- a/lib/sidekiq/middleware/client/datadog.rb
+++ b/lib/sidekiq/middleware/client/datadog.rb
@@ -1,0 +1,65 @@
+require 'sidekiq'
+require 'sidekiq/datadog/version'
+require 'sidekiq/datadog/tag_builder'
+require 'datadog/statsd'
+require 'socket'
+
+module Sidekiq
+  module Middleware
+    module Client
+      class Datadog
+        # Configure and install datadog instrumentation. Example:
+        #
+        #   Sidekiq.configure_client do |config|
+        #     config.client_middleware do |chain|
+        #       chain.add Sidekiq::Middleware::Client::Datadog
+        #     end
+        #   end
+        #
+        # You might want to also call `client_middleware` in your `configure_server` call,
+        # since enqueued jobs can enqueue other jobs.
+        #
+        # If you have other client middleware that can stop jobs from getting pushed,
+        # you might want to ensure this middleware is added last, to avoid reporting
+        # enqueues that later get stopped.
+        #
+        # Options:
+        # * <tt>:hostname</tt>    - the hostname used for instrumentation, defaults to system hostname, respects +INSTRUMENTATION_HOSTNAME+ env variable
+        # * <tt>:metric_name</tt> - the metric name (prefix) to use, defaults to "sidekiq.job_enqueued"
+        # * <tt>:tags</tt>        - array of custom tags, these can be plain strings or lambda blocks accepting a rack env instance
+        # * <tt>:skip_tags</tt>   - array of tag names that shouldn't be emitted
+        # * <tt>:statsd_host</tt> - the statsD host, defaults to "localhost", respects +STATSD_HOST+ env variable
+        # * <tt>:statsd_port</tt> - the statsD port, defaults to 8125, respects +STATSD_PORT+ env variable
+        # * <tt>:statsd</tt>      - custom statsd instance
+        def initialize(opts = {})
+          statsd_host = opts[:statsd_host] || ENV['STATSD_HOST'] || 'localhost'
+          statsd_port = (opts[:statsd_port] || ENV['STATSD_PORT'] || 8125).to_i
+
+          @metric_name  = opts[:metric_name] || 'sidekiq.job_enqueued'
+          @statsd       = opts[:statsd] || ::Datadog::Statsd.new(statsd_host, statsd_port)
+
+          # `status` is meaningless when enqueueing
+          skip_tags = Array(opts[:skip_tags]) + ['status']
+
+          @tag_builder = Sidekiq::Datadog::TagBuilder.new(
+            opts[:tags],
+            skip_tags,
+            opts[:hostname],
+          )
+        end
+
+        def call(worker_class, job, queue, _redis_pool, *)
+          record(worker_class, job, queue)
+          yield
+        end
+
+        private
+
+        def record(worker_class, job, queue)
+          tags = @tag_builder.build_tags(worker_class, job, queue)
+          @statsd.increment @metric_name, tags: tags
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -1,5 +1,6 @@
 require 'sidekiq'
 require 'sidekiq/datadog/version'
+require 'sidekiq/datadog/tag_builder'
 require 'datadog/statsd'
 require 'socket'
 
@@ -29,12 +30,11 @@ module Sidekiq
 
           @metric_name  = opts[:metric_name] || 'sidekiq.job'
           @statsd       = opts[:statsd] || ::Datadog::Statsd.new(statsd_host, statsd_port)
-          @tags         = opts[:tags] || []
-          @skip_tags    = Array(opts[:skip_tags]).map(&:to_s)
-
-          env  = Sidekiq.options[:environment] || ENV['RACK_ENV']
-          host = opts[:hostname] || ENV['INSTRUMENTATION_HOSTNAME'] || Socket.gethostname
-          setup_defaults(host: host, env: env)
+          @tag_builder  = Sidekiq::Datadog::TagBuilder.new(
+            opts[:tags],
+            opts[:skip_tags],
+            opts[:hostname],
+          )
         end
 
         def call(worker, job, queue, *)
@@ -54,7 +54,7 @@ module Sidekiq
 
         def record(worker, job, queue, start, clock, error = nil)
           msec = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :millisecond) - clock
-          tags = build_tags(worker, job, queue, error)
+          tags = @tag_builder.build_tags(worker, job, queue, error)
 
           @statsd.increment @metric_name, tags: tags
           @statsd.timing "#{@metric_name}.time", msec, tags: tags
@@ -63,54 +63,6 @@ module Sidekiq
 
           queued_ms = ((start - Time.at(job['enqueued_at'])) * 1000).round
           @statsd.timing "#{@metric_name}.queued_time", queued_ms, tags: tags
-        end
-
-        def build_tags(worker, job, queue = nil, error = nil)
-          name = underscore(job['wrapped'] || worker.class.to_s)
-          tags = @tags.flat_map do |tag|
-            case tag
-            when String then tag
-            when Proc then tag.call(worker, job, queue, error)
-            end
-          end
-          tags.compact!
-
-          tags.push "name:#{name}" if include_tag?('name')
-          tags.push "queue:#{queue}" if queue && include_tag?('queue')
-
-          if error.nil?
-            tags.push 'status:ok' if include_tag?('status')
-          else
-            kind = underscore(error.class.name.sub(/Error$/, ''))
-            tags.push 'status:error' if include_tag?('status')
-            tags.push "error:#{kind}" if include_tag?('error')
-          end
-
-          tags
-        end
-
-        def setup_defaults(hash)
-          hash.each do |key, val|
-            key = key.to_s
-            next unless val && include_tag?(key)
-
-            prefix = "#{key}:"
-            next if @tags.any? {|t| t.is_a?(String) && t.start_with?(prefix) }
-
-            @tags.push [key, val].join(':')
-          end
-        end
-
-        def include_tag?(tag)
-          !@skip_tags.include?(tag)
-        end
-
-        def underscore(word)
-          word = word.to_s.gsub(/::/, '/')
-          word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
-          word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-          word.tr!('-', '_')
-          word.downcase
         end
       end
     end

--- a/spec/sidekiq/datadog/tag_builder_spec.rb
+++ b/spec/sidekiq/datadog/tag_builder_spec.rb
@@ -73,4 +73,13 @@ describe Sidekiq::Datadog::TagBuilder do
       expect(result).to include('status:error')
     end
   end
+
+  context 'with a worker_class instead of a Worker object' do
+    let(:worker_class) { 'Module::Worker' }
+
+    it 'reports the error class, and status' do
+      result = subject.build_tags(worker_class, job, queue, error)
+      expect(result).to include('name:module/worker')
+    end
+  end
 end

--- a/spec/sidekiq/datadog/tag_builder_spec.rb
+++ b/spec/sidekiq/datadog/tag_builder_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Sidekiq::Datadog::TagBuilder do
+  let(:custom_tags) { nil }
+  let(:skip_tags) { nil }
+  let(:custom_hostname) { nil }
+
+  subject { described_class.new(custom_tags, skip_tags, custom_hostname) }
+
+  let(:worker) { Mock::Worker.new }
+  let(:job) { { 'enqueued_at' => 1461881794 } }
+  let(:queue) { 'queue_name' }
+  let(:error) { nil }
+
+  it 'builds basic default tags without any parameters' do
+    result = subject.build_tags(worker, job, queue, error)
+
+    expect(result).to eql([
+      "host:#{Socket.gethostname}",
+      'env:test',
+      'name:mock/worker',
+      'queue:queue_name',
+      'status:ok',
+    ])
+  end
+
+  context 'with custom hostname' do
+    let(:custom_hostname) { 'myhostname' }
+
+    it 'reports the custom hostname' do
+      result = subject.build_tags(worker, job, queue, error)
+      expect(result).to include('host:myhostname')
+    end
+  end
+
+  context 'with custom tags' do
+    let(:custom_tags) { ['custom:tag', ->(w, *) { "worker:#{w.class.name[1..2]}" }] }
+
+    it 'reports the custom tags, fixed and Procs' do
+      result = subject.build_tags(worker, job, queue, error)
+      expect(result).to include('custom:tag')
+      expect(result).to include('worker:oc')
+    end
+  end
+
+  context 'with skipped tags' do
+    let(:skip_tags) { %w[name env] }
+
+    it "doesn't output the skipped tags" do
+      result = subject.build_tags(worker, job, queue, error)
+      result_keys = result.map {|t| t.split(':').first }
+
+      expect(result_keys).not_to include('name')
+      expect(result_keys).not_to include('env')
+    end
+  end
+
+  context 'with a wrapped job' do
+    let(:job) { { 'wrapped' => 'Module::WrappedJobName' } }
+
+    it 'reports the wrapped job name' do
+      result = subject.build_tags(worker, job, queue, error)
+      expect(result).to include('name:module/wrapped_job_name')
+    end
+  end
+
+  context 'with an error' do
+    let(:error) { ArgumentError.new }
+
+    it 'reports the error class, and status' do
+      result = subject.build_tags(worker, job, queue, error)
+      expect(result).to include('error:argument')
+      expect(result).to include('status:error')
+    end
+  end
+end

--- a/spec/sidekiq/middleware/client/datadog_spec.rb
+++ b/spec/sidekiq/middleware/client/datadog_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe Sidekiq::Middleware::Client::Datadog do
+  let(:statsd) { Mock::Statsd.new('localhost', 55555) }
+  let(:worker_class) { 'Mock::Worker' }
+  let(:tags) do
+    ['custom:tag', ->(worker_class, *) { "worker:#{worker_class[1..2]}" }]
+  end
+  let(:options) { {} }
+
+  before do
+    statsd.messages.clear
+  end
+
+  subject { described_class.new(hostname: 'test.host', statsd: statsd, tags: tags, **options) }
+
+  it 'should send an increment event for each job enqueued' do
+    subject.call(worker_class, {}, 'default', nil) { 'ok' }
+    expect(statsd.messages).to eq([
+      'sidekiq.job_enqueued:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,'\
+        'queue:default',
+    ])
+  end
+
+  it 'should support wrappers' do
+    subject.call(worker_class, { 'wrapped' => 'wrap' }, nil, nil) { 'ok' }
+    expect(statsd.messages).to eq([
+      'sidekiq.job_enqueued:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:wrap',
+    ])
+  end
+
+  context 'with a dynamic tag list' do
+    let(:tags) do
+      ['custom:tag', ->(_w, j, *) { j['args'].map {|n| "arg:#{n}" } }]
+    end
+
+    it 'should generate the correct tags' do
+      subject.call(worker_class, { 'args' => [1, 2] }, 'default', nil) { 'ok' }
+
+      expect(statsd.messages).to eq([
+        'sidekiq.job_enqueued:1|c|#custom:tag,arg:1,arg:2,host:test.host,env:test,name:mock/worker,'\
+          'queue:default',
+      ])
+    end
+  end
+
+  context 'with a list of skipped tags' do
+    let(:tags) { [] }
+    let(:options) { { skip_tags: %i[env host name] } }
+
+    it 'should send metrics without the skipped tags' do
+      subject.call(worker_class, {}, 'default', nil) { 'ok' }
+
+      expect(statsd.messages).to eq([
+        'sidekiq.job_enqueued:1|c|#queue:default',
+      ])
+    end
+  end
+
+  context 'when sidekiq/api is required' do
+    before do
+      require 'sidekiq/api'
+    end
+
+    it 'should not raise any errors' do
+      expect do
+        subject.call(worker_class, {}, 'default', nil) { 'ok' }
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
The gem currently tracks how many jobs have been *worked* in Sidekiq's server, through a Server middleware.

We woud like to also track how many jobs have been *enqueued*, using a Client middleware.

This PR is in two parts:
- Extract all the "tag building logic" into a separate class (since we need most of that in the Client middleware too)
- Add the Client middleware, which is almost a verbatim copy of the now very small Server middleware.

It is probably easier to review the commits separately, as the reason behind the changes is clearer that way.

This change is backwards compatible with the existing gem, releasing it would be a minor version bump.