### PR TITLE
Prepare v0.6.0 release, and support `dogstats-ruby` v4.8 and >= 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ruby:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["2.5", "2.6", "2.7", "3.0"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       matrix:
         ruby-version: ["2.5", "2.6", "2.7", "3.0"]
+        gemfile: [ Gemfile, Gemfile_dogstats_v4 ]
+    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,17 @@
-require: rubocop-performance
-inherit_from:
-  - https://gitlab.com/bsm/misc/raw/master/rubocop/default.yml
+inherit_gem:
+  rubocop-bsm:
+    - default.yml
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   TargetRubyVersion: "2.5"
-Naming/FileName:
-  Exclude:
-    - "lib/sidekiq-datadog.rb"
-    - "sidekiq-datadog.gemspec"
 
 Metrics/ParameterLists:
-  Max: 10
+  Max: 8
+Naming/FileName:
+  Exclude:
+    - lib/sidekiq-datadog.rb
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-cache: bundler
-language: ruby
-before_install:
-  - gem install bundler
-rvm:
-  - 2.7
-  - 2.6
-  - 2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,61 +2,69 @@ PATH
   remote: .
   specs:
     sidekiq-datadog (0.5.3)
-      dogstatsd-ruby (>= 4.2.0)
+      dogstatsd-ruby (~> 4.2)
       sidekiq
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
-    connection_pool (2.2.3)
-    diff-lcs (1.4.2)
-    dogstatsd-ruby (4.8.1)
-    parallel (1.19.2)
-    parser (2.7.1.4)
+    ast (2.4.2)
+    connection_pool (2.2.5)
+    diff-lcs (1.4.4)
+    dogstatsd-ruby (4.8.3)
+    parallel (1.20.1)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
     rainbow (3.0.0)
-    rake (13.0.1)
-    redis (4.2.1)
-    regexp_parser (1.7.1)
+    rake (13.0.3)
+    redis (4.3.1)
+    regexp_parser (2.1.1)
     rexml (3.2.5)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
-    rubocop (0.86.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.17.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.0.3, < 1.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.0.3)
-      parser (>= 2.7.0.1)
-    rubocop-performance (1.6.1)
-      rubocop (>= 0.71.0)
-    ruby-progressbar (1.10.1)
-    sidekiq (6.0.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
+    rubocop-bsm (0.6.0)
+      rubocop (~> 1.0)
+      rubocop-performance
+      rubocop-rake
+      rubocop-rspec
+    rubocop-performance (1.11.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (2.4.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
+    sidekiq (6.2.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
-    timecop (0.9.1)
-    unicode-display_width (1.7.0)
+      redis (>= 4.2.0)
+    timecop (0.9.4)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -65,10 +73,10 @@ DEPENDENCIES
   bundler
   rake
   rspec
-  rubocop
+  rubocop-bsm
   rubocop-performance
   sidekiq-datadog!
   timecop
 
 BUNDLED WITH
-   2.1.4
+   2.2.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-datadog (0.5.3)
+    sidekiq-datadog (0.6.0)
       dogstatsd-ruby (~> 4.2)
       sidekiq
 

--- a/Gemfile_dogstats_v4
+++ b/Gemfile_dogstats_v4
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'dogstatsd-ruby', '~> 4.8'               # A statsd wrapper for reporting DataDog custom metrics

--- a/Gemfile_dogstats_v4.lock
+++ b/Gemfile_dogstats_v4.lock
@@ -11,7 +11,7 @@ GEM
     ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.4.4)
-    dogstatsd-ruby (5.1.0)
+    dogstatsd-ruby (4.8.3)
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
@@ -71,6 +71,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  dogstatsd-ruby (~> 4.8)
   rake
   rspec
   rubocop-bsm

--- a/README.md
+++ b/README.md
@@ -119,3 +119,18 @@ The base metric names `sidekiq.job` and `sidekiq.job_enqueued` can be overriden 
 4. Push to the branch (`git push origin my-new-feature`)
 5. Make a pull request
 
+
+**`dogstatsd-ruby` Version note:** `dogstatsd-ruby` has major backwards incompatibilities 
+between v4.8.3 and 5.0.0. This gem is compatible with both, and CI tests both versions.
+
+In order to test through both, we have 2 Gemfiles (and their respective `.lock` files):
+- `Gemfile`
+- `Gemfile_dogstats_v4`
+
+By default, everything runs against `dogstatsd-ruby` >= 5.0.
+
+To update `Gemfile_dogstats_v4.lock`, or run tests with c4.8:
+
+`BUNDLE_GEMFILE=Gemfile_dogstats_v4 bundle update`
+
+`BUNDLE_GEMFILE=Gemfile_dogstats_v4 bundle exec rspec`

--- a/Rakefile
+++ b/Rakefile
@@ -20,4 +20,4 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
-task default: %i[spec rubocop]
+task default: %i[rubocop spec]

--- a/lib/sidekiq-datadog.rb
+++ b/lib/sidekiq-datadog.rb
@@ -1,2 +1,1 @@
-require 'sidekiq/middleware/client/datadog'
-require 'sidekiq/middleware/server/datadog'
+require 'sidekiq/datadog'

--- a/lib/sidekiq/datadog.rb
+++ b/lib/sidekiq/datadog.rb
@@ -1,0 +1,3 @@
+require 'sidekiq/datadog/version'
+require 'sidekiq/middleware/client/datadog'
+require 'sidekiq/middleware/server/datadog'

--- a/lib/sidekiq/datadog/version.rb
+++ b/lib/sidekiq/datadog/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Datadog
-    VERSION = '0.5.3'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end

--- a/lib/sidekiq/middleware/client/datadog.rb
+++ b/lib/sidekiq/middleware/client/datadog.rb
@@ -58,6 +58,8 @@ module Sidekiq
         def record(worker_class, job, queue)
           tags = @tag_builder.build_tags(worker_class, job, queue)
           @statsd.increment @metric_name, tags: tags
+
+          @statsd.flush if @statsd.respond_to?(:flush) # dogstatsd-ruby >= 5.0.0
         end
       end
     end

--- a/lib/sidekiq/middleware/server/datadog.rb
+++ b/lib/sidekiq/middleware/server/datadog.rb
@@ -63,6 +63,8 @@ module Sidekiq
 
           queued_ms = ((start - Time.at(job['enqueued_at'])) * 1000).round
           @statsd.timing "#{@metric_name}.queued_time", queued_ms, tags: tags
+
+          @statsd.flush if @statsd.respond_to?(:flush) # dogstatsd-ruby >= 5.0.0
         end
       end
     end

--- a/sidekiq-datadog.gemspec
+++ b/sidekiq-datadog.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5'
 
-  s.add_runtime_dependency('dogstatsd-ruby', '>= 4.2.0')
+  s.add_runtime_dependency('dogstatsd-ruby', '~> 4.2')
   s.add_runtime_dependency('sidekiq')
 
   s.add_development_dependency('bundler')

--- a/sidekiq-datadog.gemspec
+++ b/sidekiq-datadog.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5'
 
-  s.add_runtime_dependency('dogstatsd-ruby', '~> 4.2')
+  s.add_runtime_dependency('dogstatsd-ruby', '>= 4.2.0')
   s.add_runtime_dependency('sidekiq')
 
   s.add_development_dependency('bundler')

--- a/sidekiq-datadog.gemspec
+++ b/sidekiq-datadog.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler')
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')
-  s.add_development_dependency('rubocop')
+  s.add_development_dependency('rubocop-bsm')
   s.add_development_dependency('rubocop-performance')
   s.add_development_dependency('timecop')
 end

--- a/spec/sidekiq/datadog/tag_builder_spec.rb
+++ b/spec/sidekiq/datadog/tag_builder_spec.rb
@@ -1,16 +1,15 @@
 require 'spec_helper'
 
 describe Sidekiq::Datadog::TagBuilder do
-  let(:custom_tags) { nil }
-  let(:skip_tags) { nil }
-  let(:custom_hostname) { nil }
-
   subject { described_class.new(custom_tags, skip_tags, custom_hostname) }
 
+  let(:custom_tags) { nil }
   let(:worker) { Mock::Worker.new }
   let(:job) { { 'enqueued_at' => 1461881794 } }
   let(:queue) { 'queue_name' }
   let(:error) { nil }
+  let(:skip_tags) { nil }
+  let(:custom_hostname) { nil }
 
   it 'builds basic default tags without any parameters' do
     result = subject.build_tags(worker, job, queue, error)

--- a/spec/sidekiq/datadog_spec.rb
+++ b/spec/sidekiq/datadog_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe Sidekiq::Datadog do
   it 'has a version' do
-    expect(Sidekiq::Datadog::VERSION).to be_instance_of(String)
+    expect(described_class::VERSION).to be_instance_of(String)
   end
 end

--- a/spec/sidekiq/middleware/server/datadog_spec.rb
+++ b/spec/sidekiq/middleware/server/datadog_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Sidekiq::Middleware::Server::Datadog do
+  subject { described_class.new(hostname: 'test.host', statsd: statsd, tags: tags, **options) }
+
   let(:statsd) { Mock::Statsd.new('localhost', 55555) }
   let(:worker) { Mock::Worker.new }
   let(:tags) do
@@ -22,9 +24,7 @@ describe Sidekiq::Middleware::Server::Datadog do
     Timecop.freeze(Time.at(enqueued_at + expected_queued_time_ms.to_f / 1000))
   end
 
-  subject { described_class.new(hostname: 'test.host', statsd: statsd, tags: tags, **options) }
-
-  it 'should send an increment and timing event for each job run' do
+  it 'sends an increment and timing event for each job run' do
     subject.call(worker, { 'enqueued_at' => enqueued_at }, 'default') { 'ok' }
     expect(statsd.messages).to eq([
       'sidekiq.job:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:mock/worker,'\
@@ -36,7 +36,7 @@ describe Sidekiq::Middleware::Server::Datadog do
     ])
   end
 
-  it 'should support wrappers' do
+  it 'supports wrappers' do
     subject.call(worker, { 'enqueued_at' => enqueued_at, 'wrapped' => 'wrap' }, nil) { 'ok' }
     expect(statsd.messages).to eq([
       'sidekiq.job:1|c|#custom:tag,worker:oc,host:test.host,env:test,name:wrap,status:ok',
@@ -46,7 +46,7 @@ describe Sidekiq::Middleware::Server::Datadog do
     ])
   end
 
-  it 'should handle errors' do
+  it 'handles errors' do
     expect(lambda {
       subject.call(worker, {}, nil) { raise 'doh!' }
     }).to raise_error('doh!')
@@ -64,7 +64,7 @@ describe Sidekiq::Middleware::Server::Datadog do
       ['custom:tag', ->(_w, j, *) { j['args'].map {|n| "arg:#{n}" } }]
     end
 
-    it 'should generate the correct tags' do
+    it 'generates the correct tags' do
       subject.call(worker, { 'enqueued_at' => enqueued_at, 'args' => [1, 2] }, 'default') { 'ok' }
 
       expect(statsd.messages).to eq([
@@ -82,7 +82,7 @@ describe Sidekiq::Middleware::Server::Datadog do
     let(:tags) { [] }
     let(:options) { { skip_tags: %i[env host name] } }
 
-    it 'should send metrics without the skipped tags' do
+    it 'sends metrics without the skipped tags' do
       subject.call(worker, { 'enqueued_at' => 1461881794.9312189 }, 'default') { 'ok' }
 
       expect(statsd.messages).to eq([
@@ -98,7 +98,7 @@ describe Sidekiq::Middleware::Server::Datadog do
       require 'sidekiq/api'
     end
 
-    it 'should not raise any errors' do
+    it 'does not raise any errors' do
       expect do
         subject.call(worker, { 'enqueued_at' => enqueued_at }, 'default') { 'ok' }
       end.not_to raise_error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'sidekiq-datadog'
 require 'timecop'
 
 module Mock
-  class Worker; end
+  class Worker; end # rubocop:disable Lint/EmptyClass
 
   class Statsd < ::Datadog::Statsd
     def send_stat(message)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,9 @@ module Mock
   class Worker; end # rubocop:disable Lint/EmptyClass
 
   class Statsd < ::Datadog::Statsd
-    def send_stat(message)
-      messages.push message
+    def send_stats(stat, delta, type, opts = EMPTY_OPTIONS)
+      full_stat = serializer.to_stat(stat, delta, type, tags: opts[:tags])
+      messages.push full_stat
     end
 
     def messages


### PR DESCRIPTION
Prepare to release a new `0.6.0` version, with the new features, plus support for `dogstats-ruby` `>=4.2.0` and `>=5.0`.

`dogstatsd-ruby` has major backwards incompatibilities between v4.8.3 and 5.0.0. 
This gem is now compatible with both, and CI tests both versions.

We also updated our Rubocop ruleset, and moved from TravisCI to Github Actions.