### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0"]
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1"]
         gemfile: [ Gemfile, Gemfile_dogstats_v4 ]
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.